### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-server"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nugine <nugine@foxmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -12,7 +12,7 @@ categories = ["web-programming", "web-programming::http-server"]
 rust-version = "1.59"
 
 [features]
-default = ["binary"]
+default = []
 binary = [
     "anyhow", 
     "dotenv", 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An experimental generic S3 server
 From cargo:
 
 ```
-cargo install s3-server
+cargo install s3-server --features binary
 ```
 
 From source:
@@ -38,7 +38,7 @@ s3-server --help
 ## Usage
 
 ```
-s3-server 0.1.0
+s3-server 0.2.0
 
 USAGE:
     s3-server [OPTIONS]

--- a/src/bin/s3-server.rs
+++ b/src/bin/s3-server.rs
@@ -1,5 +1,5 @@
 //! ```shell
-//! s3-server 0.1.0-dev
+//! s3-server 0.2.0-dev
 //!
 //! USAGE:
 //!     s3-server [OPTIONS]


### PR DESCRIPTION
This PR is to prepare for publishing changes including #83, #85, #107. I will release s3-server v0.2.0 after this PR is merged.
The version is bumped to v0.2.0 instead of v0.1.1 because #85 changes the MSRV and requires Rust 1.59.
@pwang7 