### PR TITLE
Handle byte range in FileSystem::get_object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
           touch remove-packages.list
 
           sed -i 's/mc.${MC_VERSION}/archive\/mc.${MC_VERSION}/' build/mc/install.sh
-          
+
+          # lock mc version
+          sed -i 's/^MC_VERSION.*/MC_VERSION=RELEASE.2022-03-09T02-08-36Z/g' build/mc/install.sh
+
           # delete tests for minio
           cat >> build/mc/install.sh << EOF
           sed -i '/^\s*test_rb\s*$/d' "\$test_run_dir/functional-tests.sh"

--- a/src/data_structures/bytes_stream.rs
+++ b/src/data_structures/bytes_stream.rs
@@ -1,8 +1,8 @@
 //! `BytesStream`
 
-use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::{io, mem};
 
 use futures::stream::Stream;
 use hyper::body::Bytes;
@@ -13,13 +13,20 @@ pin_project! {
         #[pin]
         reader: R,
         buf_size: usize,
+        buf: Vec<u8>,
+        limit: Option<usize>,
     }
 }
 
 impl<R> BytesStream<R> {
     /// Constructs a `BytesStream`
-    pub const fn new(reader: R, buf_size: usize) -> Self {
-        Self { reader, buf_size }
+    pub const fn new(reader: R, buf_size: usize, limit: Option<usize>) -> Self {
+        Self {
+            reader,
+            buf_size,
+            buf: Vec::new(),
+            limit,
+        }
     }
 }
 
@@ -27,20 +34,27 @@ impl<R: futures::AsyncRead> Stream for BytesStream<R> {
     type Item = io::Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // FIXME: reuse the buf
-        let mut buf = vec![0_u8; self.buf_size];
-
         let this = self.project();
 
-        let ret: io::Result<usize> = futures::ready!(this.reader.poll_read(cx, &mut buf));
+        let buf_len = match *this.limit {
+            Some(lim) => lim.min(*this.buf_size),
+            None => *this.buf_size,
+        };
+        this.buf.resize(buf_len, 0);
+
+        let ret: io::Result<usize> = futures::ready!(this.reader.poll_read(cx, this.buf));
         let ans: Option<io::Result<Bytes>> = match ret {
+            Ok(n) if n == 0 => None,
             Ok(n) => {
-                if n == 0 {
-                    None
-                } else {
-                    buf.truncate(n);
-                    Some(Ok(buf.into()))
+                let nread = n.min(buf_len);
+                this.buf.truncate(nread);
+                let buf = Bytes::from(mem::take(this.buf));
+
+                if let Some(ref mut lim) = *this.limit {
+                    *lim = lim.wrapping_sub(nread);
                 }
+
+                Some(Ok(buf))
             }
             Err(e) => Some(Err(e)),
         };

--- a/src/headers/mod.rs
+++ b/src/headers/mod.rs
@@ -4,11 +4,13 @@ mod amz_content_sha256;
 mod amz_copy_source;
 mod amz_date;
 mod authorization_v4;
+mod range;
 
 pub use self::amz_content_sha256::AmzContentSha256;
 pub use self::amz_copy_source::AmzCopySource;
 pub use self::amz_date::AmzDate;
 pub use self::authorization_v4::{AuthorizationV4, CredentialV4};
+pub use self::range::Range;
 
 pub use hyper::header::*;
 

--- a/src/headers/range.rs
+++ b/src/headers/range.rs
@@ -1,0 +1,140 @@
+//! HTTP Range header
+
+/// HTTP Range header
+///
+/// See <https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35>
+#[allow(clippy::exhaustive_enums, missing_copy_implementations)]
+#[derive(Debug, Clone)]
+pub enum Range {
+    /// Normal byte range
+    Normal {
+        /// first
+        first: u64,
+        /// last
+        last: Option<u64>,
+    },
+    /// Suffix byte range
+    Suffix {
+        /// last
+        last: u64,
+    },
+}
+
+/// `ParseRangeError`
+#[allow(missing_copy_implementations)] // Why? See `crate::path::ParseS3PathError`.
+#[derive(Debug, thiserror::Error)]
+#[error("ParseRangeError")]
+pub struct ParseRangeError {
+    /// private place holder
+    _priv: (),
+}
+
+impl Range {
+    /// Parses `Range` from header
+    /// # Errors
+    /// Returns an error if the header is invalid
+    pub fn from_header_str(header: &str) -> Result<Self, ParseRangeError> {
+        /// nom parser
+        fn parse(input: &str) -> nom::IResult<&str, Range> {
+            use nom::{
+                branch::alt,
+                bytes::complete::tag,
+                character::complete::digit1,
+                combinator::{all_consuming, map, map_res, opt},
+                sequence::tuple,
+            };
+
+            let normal_parser = map_res(
+                tuple((
+                    map_res(digit1, str::parse::<u64>),
+                    tag("-"),
+                    opt(map_res(digit1, str::parse::<u64>)),
+                )),
+                |ss: (u64, &str, Option<u64>)| {
+                    if let (first, Some(last)) = (ss.0, ss.2) {
+                        if first > last {
+                            return Err(ParseRangeError { _priv: () });
+                        }
+                    }
+                    Ok(Range::Normal {
+                        first: ss.0,
+                        last: ss.2,
+                    })
+                },
+            );
+
+            let suffix_parser = map(
+                tuple((tag("-"), map_res(digit1, str::parse::<u64>))),
+                |ss: (&str, u64)| Range::Suffix { last: ss.1 },
+            );
+
+            let mut parser =
+                all_consuming(tuple((tag("bytes="), alt((normal_parser, suffix_parser)))));
+
+            let (input, (_, ans)) = parser(input)?;
+
+            Ok((input, ans))
+        }
+
+        match parse(header) {
+            Err(_) => Err(ParseRangeError { _priv: () }),
+            Ok((_, ans)) => Ok(ans),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_range() {
+        {
+            let src = "bytes=0-499";
+            let result = Range::from_header_str(src);
+            assert!(matches!(
+                result.unwrap(),
+                Range::Normal {
+                    first: 0,
+                    last: Some(499)
+                }
+            ));
+        }
+        {
+            let src = "bytes=0-499;";
+            let result = Range::from_header_str(src);
+            assert!(result.is_err());
+        }
+        {
+            let src = "bytes=9500-";
+            let result = Range::from_header_str(src);
+            assert!(matches!(
+                result.unwrap(),
+                Range::Normal {
+                    first: 9500,
+                    last: None
+                }
+            ));
+        }
+        {
+            let src = "bytes=9500-0-";
+            let result = Range::from_header_str(src);
+            assert!(result.is_err());
+        }
+        {
+            let src = "bytes=-500";
+            let result = Range::from_header_str(src);
+            assert!(matches!(result.unwrap(), Range::Suffix { last: 500 }));
+        }
+        {
+            let src = "bytes=-500 ";
+            let result = Range::from_header_str(src);
+            assert!(result.is_err());
+        }
+        {
+            let src = "bytes=-1000000000000000000000000";
+            let result = Range::from_header_str(src);
+            assert!(result.is_err());
+        }
+    }
+}

--- a/src/storages/fs.rs
+++ b/src/storages/fs.rs
@@ -348,7 +348,7 @@ impl S3Storage for FileSystem {
         let file_metadata = trace_try!(file.metadata().await);
         let last_modified = time::to_rfc3339(trace_try!(file_metadata.modified()));
         let content_length = file_metadata.len();
-        let stream = BytesStream::new(file, 4096);
+        let stream = BytesStream::new(file, 4096, None);
 
         let object_metadata = trace_try!(self.load_metadata(&input.bucket, &input.key).await);
 


### PR DESCRIPTION
Resolves #111 

The fs storage should handle the byte range in GetObject requests. Otherwise it will cause unexpected downloading results.

Related issue: #110

@pwang7 